### PR TITLE
Fix resizing the menu bigger again

### DIFF
--- a/src/priority-plus-navigation.vue
+++ b/src/priority-plus-navigation.vue
@@ -97,8 +97,7 @@ export default {
       const lastVisibleItemIndex = this.getLastVisibleItemIndex()
 
       this.list.forEach((item, index) => {
-        const hidden = index > lastVisibleItemIndex
-        this.$set(item, 'hidden', hidden)
+        item.hidden = index > lastVisibleItemIndex
       })
     }
   },

--- a/src/priority-plus-navigation.vue
+++ b/src/priority-plus-navigation.vue
@@ -45,10 +45,6 @@ export default {
     window.addEventListener('resize', this.handleResize)
   },
 
-  beforeUpdate () {
-    this.handleResize()
-  },
-
   beforeDestroy () {
     window.removeEventListener('resize', this.handleResize)
   },

--- a/src/priority-plus-navigation.vue
+++ b/src/priority-plus-navigation.vue
@@ -67,9 +67,7 @@ export default {
       let offset = 0
 
       if (this.hasHiddenItems) {
-        const els = Array.prototype.slice.call(this.$el.children || [])
-        const el = els[els.length - 1]
-        els && el && ( offset = offset + ( el.offsetWidth * 2 ) )
+        offset = getWidth(this.$el.children[this.$el.children.length - 1])
       }
 
       return this.getContainerWidth() - offset

--- a/src/priority-plus-navigation.vue
+++ b/src/priority-plus-navigation.vue
@@ -4,7 +4,7 @@ function getWidth(el) {
   const margin = parseFloat(styles['marginLeft']) +
     parseFloat(styles['marginRight'])
 
-  return Math.ceil(el.offsetWidth + margin)
+  return Math.ceil(el.getBoundingClientRect().width + margin)
 }
 
 export default {
@@ -61,6 +61,10 @@ export default {
     },
 
     getContainerWidth () {
+      return Math.ceil(this.$el.getBoundingClientRect().width)
+    },
+
+    getAdjustedContainerWidth () {
       let offset = 0
 
       if (this.hasHiddenItems) {
@@ -69,15 +73,14 @@ export default {
         els && el && ( offset = offset + ( el.offsetWidth * 2 ) )
       }
 
-      return this.$el.offsetWidth - offset
+      return this.getContainerWidth() - offset
     },
 
     getLastVisibleItemIndex () {
       let index = 0
-      const containerWidth = this.getContainerWidth()
-
+      const adjustedContainerWidth = this.getAdjustedContainerWidth()
       while (index < this.accumItemWidths.length) {
-        if (this.accumItemWidths[index] > containerWidth) {
+        if (this.accumItemWidths[index] > adjustedContainerWidth) {
           index--
           break
         }

--- a/src/priority-plus-navigation.vue
+++ b/src/priority-plus-navigation.vue
@@ -20,14 +20,16 @@ export default {
 
   data () {
     return {
-      accumItemWidths: []
+      accumItemWidths: [],
+      isOverflowing: false
     }
   },
 
   render () {
     return this.$scopedSlots.default({
       mainItems: this.mainItems,
-      moreItems: this.moreItems
+      moreItems: this.moreItems,
+      isOverflowing: this.isOverflowing
     })
   },
 
@@ -66,7 +68,7 @@ export default {
     getAdjustedContainerWidth () {
       let offset = 0
 
-      if (this.hasHiddenItems) {
+      if (this.isOverflowing) {
         offset = getWidth(this.$el.children[this.$el.children.length - 1])
       }
 
@@ -88,6 +90,8 @@ export default {
     },
 
     async handleResize () {
+      this.isOverflowing = this.accumItemWidths[this.accumItemWidths.length - 1] > this.getContainerWidth()
+
       await this.$nextTick()
 
       const lastVisibleItemIndex = this.getLastVisibleItemIndex()
@@ -106,10 +110,6 @@ export default {
 
     moreItems () {
       return this.list.filter((item) => item.hidden)
-    },
-
-    hasHiddenItems () {
-      return !!this.moreItems.length
     }
   }
 }

--- a/src/priority-plus-navigation.vue
+++ b/src/priority-plus-navigation.vue
@@ -52,9 +52,8 @@ export default {
   methods: {
     storeItemWidths () {
       let sum = 0
-      const els = Array.prototype.slice.call(this.$el.children || [])
       this.list.forEach((item, index) => {
-        this.$set(item, 'width', getWidth(els[index]))
+        this.$set(item, 'width', getWidth(this.$el.children[index]))
         sum += item.width
         this.$set(this.accumItemWidths, index, sum)
       })


### PR DESCRIPTION
There's a bunch of changes here but the key one is calculating whether the menu is overflowing by using the widths of the container and items rather than relying on whether there are hidden items. The previous method caused the browser to hang for me (removing the `beforeUpdate` callback fixed that). With these changes, the browser no longer hangs even with the `beforeUpdate` callback but I don't think this one is necessary as I'm not sure what could change about the menu unless perhaps a change in a parent component results in a change in size of a list item?

There are more details in each commit.

Let me know if you need any more details.