### PR TITLE
Add offsetFactor prop & clean-up offset calculation

### DIFF
--- a/src/priority-plus-navigation.vue
+++ b/src/priority-plus-navigation.vue
@@ -15,6 +15,10 @@ export default {
       type: Array,
       required: true,
       default () { return [] }
+    },
+    offsetFactor: {
+      type: Number,
+      default: 2.0
     }
   },
 
@@ -70,7 +74,7 @@ export default {
       if (this.hasHiddenItems) {
         const els = Array.prototype.slice.call(this.$el.children || [])
         const el = els[els.length - 1]
-        els && el && ( offset = offset + ( el.offsetWidth * 2 ) )
+        els && el && ( offset = getWidth(el) * this.offsetFactor )
       }
 
       return this.$el.offsetWidth - offset


### PR DESCRIPTION
Add a prop `offsetFactor` to allow the offset to be adjusted.

Use a default `offsetFactor` of 2.0 to maintain backwards compatibility.

Remove the `offset +` as it's always zero and is therefore a no-op.

Use `getWidth(el)` instead o `el.offsetWidth`